### PR TITLE
add project.urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dev = [
   "twine"
 ]
 
+[project.urls]
+Homepage = "https://www.acter.global/"
+Repository = "https://github.com/acterglobal/synapse-super-invites/"
+
 [build-system]
 requires = [
   "setuptools",


### PR DESCRIPTION
This change should make links to acter.global and to this repo appear on the pypi page, as suggested [here](https://matrix.to/#/!QQpfJfZvqxbCfeDgCj:matrix.org/$70N1ppJg8CcAjDUWARB8_S3pQLgnyyckxjdWR9Xv4c4?via=matrix.org&via=envs.net&via=beeper.com).